### PR TITLE
GetFolders: Fix Invalid URL

### DIFF
--- a/folders.go
+++ b/folders.go
@@ -58,7 +58,7 @@ func (q *Client) GetFolder(params *GetFolderParams) *Folder {
 func (q *Client) GetFolders(params *GetFoldersParams) []*Folder {
 	required(params.Ids, "Ids is required for /folder/ids")
 
-	resp := q.getJson(apiUrlResource("folders/"+strings.Join(params.Ids, ",")), map[string]string{})
+	resp := q.getJson(apiUrlResource("folders/?ids="+strings.Join(params.Ids, ",")), map[string]string{})
 	parsed := parseJsonObject(resp)
 
 	return hydrateFolders(parsed)


### PR DESCRIPTION
As noted [in the documentation](https://fb.quip.com/dev/automation/documentation#folders-get), getting multiple folders uses the path:
* `/folders/?ids=id1,id2,id3`

go-quip is doing:
* `/folders/id1,id2,id3`

Might have been an API change on Quip's side but this fixes it.